### PR TITLE
Add CI with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".rubocop.yml"
+      - "*.gemspec"
+      - lib/**
+      - spec/**
+      - Rakefile
+      - Gemfile
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7, jruby, truffleruby]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: gems-${{ matrix.ruby }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install latest bundler
+        run: |
+          gem install bundler --no-document
+          bundle config set without 'tools benchmarks docs'
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run Rubocop
+        run: bundle exec rubocop --parallel
+      - name: Run all tests
+        run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # cloudimage-rb
 
-`cloudimage-rb` is the official ruby API wrapper for
+`cloudimage-rb` is the official Ruby API wrapper for
 [Cloudimage's API](https://docs.cloudimage.io/go/cloudimage-documentation-v7/en/introduction).
+
+Supports Ruby `2.4` and above, `JRuby`, and `TruffleRuby`.
 
 ## Installation
 


### PR DESCRIPTION
Adds CI flow using Github Actions. Runs `rubocop` and specs for every PR on a matrix of Ruby versions.