### PR TITLE
Add support for custom CNAMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .rspec_status
 
 /.vscode/
+
+# benchmarks
+test.rb

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Supports Ruby `2.4` and above, `JRuby`, and `TruffleRuby`.
     - [Method aliases](#method-aliases)
     - [Custom helpers](#custom-helpers)
     - [URL aliases](#url-aliases)
+    - [CNAME](#cname)
     - [Security](#security)
       - [URL signature](#url-signature)
       - [URL sealing](#url-sealing)
@@ -41,7 +42,7 @@ Or install it yourself as:
 
 ## Usage
 
-The only requirement to get started is your customer token. You can
+The most common way to use Cloudimage is by means of your customer token. You can
 find it within your Admin interface:
 
 ![token](docs/token.png)
@@ -55,13 +56,14 @@ client = Cloudimage::Client.new(token: 'mysecrettoken')
 
 Cloudimage client accepts the following options:
 
-| Option             | Required? | Type    | Additional info                                     |
-| ------------------ | --------- | ------- | --------------------------------------------------- |
-| `token`            | Yes       | string  |                                                     |
-| `salt`             | No        | string  | See [Security](#security).                          |
-| `signature_length` | No        | integer | Integer value in the range `6..40`. Defaults to 18. |
-| `sign_urls`        | No        | boolean | Defaults to `true`. See [Security](#security).      |
-| `aliases`          | No        | hash    | See [URL aliases](#url-aliases).                    |
+| Option             | Type    | Additional info                                               |
+| ------------------ | ------- | ------------------------------------------------------------- |
+| `token`            | string  | Required if `cname` is missing.                               |
+| `cname`            | string  | Required if `token` is missing. See [CNAME](#cname).          |
+| `salt`             | string  | Optional. See [Security](#security).                          |
+| `signature_length` | integer | Optional. Integer value in the range `6..40`. Defaults to 18. |
+| `sign_urls`        | boolean | Optional. Defaults to `true`. See [Security](#security).      |
+| `aliases`          | hash    | Optional. See [URL aliases](#url-aliases).                    |
 
 Calling `path` on the client object returns an instance of `Cloudimage::URI`.
 It accepts path to the image as a string and we we will use it to build
@@ -143,6 +145,17 @@ prefix = 'https://store.s3-us-west-2.amazonaws.com/uploads/'
 client = Cloudimage::Client.new(token: 'token', aliases: { prefix => '' })
 client.path('https://store.s3-us-west-2.amazonaws.com/uploads/image.jpg').to_url
 # => "https://token.cloudimg.io/v7/image.jpg"
+```
+
+### CNAME
+
+If you have a custom CNAME configured for your account, you can
+use it to initialize the client:
+
+```ruby
+client = Cloudimage::Client.new(cname: 'img.klimo.io')
+client.path('/assets/image.jpg').to_url
+# => 'https://img.klimo.io/v7/assets/image.jpg'
 ```
 
 ### Security

--- a/lib/cloudimage/client.rb
+++ b/lib/cloudimage/client.rb
@@ -14,6 +14,7 @@ module Cloudimage
     def initialize(**options)
       @config = {}
       @config[:token] = options[:token]
+      @config[:cname] = options[:cname]
       @config[:salt] = options[:salt]
       @config[:signature_length] =
         options[:signature_length] || DEFAULT_SIGNATURE_LENGTH
@@ -21,7 +22,7 @@ module Cloudimage
       @config[:sign_urls] = options[:sign_urls].nil? ? true : false
       @config[:aliases] = options[:aliases] || {}
 
-      ensure_valid_config
+      assert_valid_config
     end
 
     def path(path)
@@ -30,18 +31,19 @@ module Cloudimage
 
     private
 
-    def ensure_valid_config
-      ensure_valid_token
-      ensure_valid_signature_length
+    def assert_valid_config
+      assert_token_or_cname
+      assert_valid_signature_length
     end
 
-    def ensure_valid_token
-      return unless config[:token].nil?
+    def assert_token_or_cname
+      return unless config[:token].nil? && config[:cname].nil?
 
-      raise InvalidConfig, 'Please specify your Cloudimage customer token.'
+      raise InvalidConfig,
+            'Please specify your customer token or a custom CNAME.'
     end
 
-    def ensure_valid_signature_length
+    def assert_valid_signature_length
       return if config[:salt].nil?
       return if (6..40).cover? config[:signature_length]
 

--- a/lib/cloudimage/uri.rb
+++ b/lib/cloudimage/uri.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 require_relative 'params'
 require_relative 'custom_helpers'
 require_relative 'security'
@@ -43,6 +45,8 @@ module Cloudimage
     private
 
     def site
+      return "https://#{config[:cname]}" if config[:cname]
+
       "https://#{config[:token]}.cloudimg.io"
     end
 

--- a/spec/cloudimage/client_spec.rb
+++ b/spec/cloudimage/client_spec.rb
@@ -2,9 +2,14 @@
 
 describe Cloudimage::Client do
   describe 'initialization' do
-    it 'raises an error without a token' do
+    it 'raises an error without a token or a CNAME' do
       expect { described_class.new }
-        .to raise_error Cloudimage::InvalidConfig, /Cloudimage customer token/
+        .to raise_error Cloudimage::InvalidConfig, /specify your customer token/
+    end
+
+    it 'accepts CNAME config' do
+      expect { described_class.new(cname: 'img.example.com') }
+        .not_to raise_error
     end
 
     context 'URL signatures' do

--- a/spec/cloudimage/uri_spec.rb
+++ b/spec/cloudimage/uri_spec.rb
@@ -116,6 +116,13 @@ describe Cloudimage::URI do
     end
   end
 
+  it 'handles custom CNAMEs' do
+    client = Cloudimage::Client.new(cname: 'img.klimo.io')
+    base = 'https://img.klimo.io/v7'
+    path = '/assets/image.jpg'
+    expect(client.path(path).to_url).to eq base + path
+  end
+
   context 'custom helpers' do
     describe 'positionable_crop' do
       it 'returns image URL with params encoded' do


### PR DESCRIPTION
Custom CNAME will be used to build URL if provided as a config option `cname`.

TODOs

- [x] docs

Closes #13